### PR TITLE
Actually print __GLASGOW_HASKELL__ in the comments

### DIFF
--- a/Data/Vector/Unboxed/Deriving.hs
+++ b/Data/Vector/Unboxed/Deriving.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS -Wall #-}
 
+#pragma push_macro("__GLASGOW_HASKELL__")
+#undef __GLASGOW_HASKELL__
 {-|
 Module:      Data.Vector.Unboxed.Deriving
 Copyright:   © 2012−2014 Liyang HU
@@ -42,6 +44,7 @@ method names to be in scope in order to define the appropriate instances:
 Consult the <https://github.com/liyang/vector-th-unbox/blob/master/tests/sanity.hs sanity test>
 for a working example.
 -}
+#pragma pop_macro("__GLASGOW_HASKELL__")
 
 module Data.Vector.Unboxed.Deriving (derivingUnbox) where
 


### PR DESCRIPTION
Currently, the Haddock pages for `vector-th-unbox` have a bug in which the `__GLASGOW_HASKELL__` macro gets expanded to an actual number within comments (see [here](http://hackage.haskell.org/package/vector-th-unbox-0.2.1.0/docs/Data-Vector-Unboxed-Deriving.html) for example, note `#if 706 == 704`). I attempt to solve this CPP oddity... with more CPP oddities. I know that both `gcc` and `clang` support `push_macro` and `pop_macro`, so this should be portable.