### PR TITLE
Fix build with template-haskell-2.11

### DIFF
--- a/Data/Vector/Unboxed/Deriving.hs
+++ b/Data/Vector/Unboxed/Deriving.hs
@@ -114,7 +114,17 @@ derivingUnbox name argsQ toRepQ fromRepQ = do
 
     s <- VarT <$> newName "s"
     let newtypeMVector = NewtypeInstD [] ''MVector [s, typ]
-            (NormalC mvName [(NotStrict, ConT ''MVector `AppT` s `AppT` rep)]) []
+#if MIN_VERSION_template_haskell(2,11,0)
+            Nothing
+#endif
+            (NormalC mvName [(
+#if MIN_VERSION_template_haskell(2,11,0)
+                               Bang NoSourceUnpackedness NoSourceStrictness
+#else
+                               NotStrict
+#endif
+                             , ConT ''MVector `AppT` s `AppT` rep
+                             )]) []
     let mvCon = ConE mvName
     let instanceMVector = InstanceD cxts
             (ConT ''M.MVector `AppT` ConT ''MVector `AppT` typ) $ concat
@@ -135,7 +145,17 @@ derivingUnbox name argsQ toRepQ fromRepQ = do
             , wrap 'M.basicUnsafeGrow       [mv, n]     (liftE mvCon) ]
 
     let newtypeVector = NewtypeInstD [] ''Vector [typ]
-            (NormalC vName [(NotStrict, ConT ''Vector `AppT` rep)]) []
+#if MIN_VERSION_template_haskell(2,11,0)
+            Nothing
+#endif
+            (NormalC vName [(
+#if MIN_VERSION_template_haskell(2,11,0)
+                              Bang NoSourceUnpackedness NoSourceStrictness
+#else
+                              NotStrict
+#endif
+                            , ConT ''Vector `AppT` rep
+                            )]) []
     let vCon  = ConE vName
     let instanceVector = InstanceD cxts
             (ConT ''G.Vector `AppT` ConT ''Vector `AppT` typ) $ concat


### PR DESCRIPTION
GHC 8.0 (specifically, `template-haskell-2.11.0.0`) introduces some breaking API changes, so this PR uses CPP to get around them. Fixes #11.