### PR TITLE
Build fails on FreeBSD-12.0 ghc-8.6.3

### DIFF
--- a/Data/Vector/Unboxed/Deriving.hs
+++ b/Data/Vector/Unboxed/Deriving.hs
@@ -15,7 +15,7 @@
 
 {-|
 Module:      Data.Vector.Unboxed.Deriving
-Copyright:   2012−2015 Liyang HU
+Copyright:   2012-2015 Liyang HU
 License:     BSD3
 Maintainer:  vector-th-unbox@liyang.hu
 Stability:   experimental

--- a/Data/Vector/Unboxed/Deriving.hs
+++ b/Data/Vector/Unboxed/Deriving.hs
@@ -15,7 +15,7 @@
 
 {-|
 Module:      Data.Vector.Unboxed.Deriving
-Copyright:   © 2012−2015 Liyang HU
+Copyright:   2012−2015 Liyang HU
 License:     BSD3
 Maintainer:  vector-th-unbox@liyang.hu
 Stability:   experimental


### PR DESCRIPTION
This PR fixes a fatal build issue. To reproduce: 

**cabal new-build** results with the following:
Resolving dependencies...
Build profile: -w ghc-8.6.3 -O1
In order, the following will be built (use -v for more details):
 - vector-th-unbox-0.2.1.6 (lib) (first run)
Configuring library for vector-th-unbox-0.2.1.6..
Preprocessing library for vector-th-unbox-0.2.1.6..
Building library for vector-th-unbox-0.2.1.6..
ghc: fd:16: hGetContents: invalid argument (invalid byte sequence)

Data/Vector/Unboxed/Deriving.hs:18:21: error:
     warning: treating Unicode character <U+2212> as identifier character rather than as '-' symbol [-Wunicode-homoglyph]
   |
18 | Copyright:   ? 2012?2015 Liyang HU
   |                     ^
`cc' failed in phase `C pre-processor'. (Exit code: -13)